### PR TITLE
add dropfirst/droplast options

### DIFF
--- a/lib/check_graphite.rb
+++ b/lib/check_graphite.rb
@@ -30,7 +30,7 @@ module CheckGraphite
         req.basic_auth options.username, options.password
       end
 
-      res = Net::HTTP.start(uri.hostname, uri.port) { |http|
+      res = Net::HTTP.start(uri.host, uri.port) { |http|
         http.request(req)
       }
 


### PR DESCRIPTION
when slicing a time frame in graphite, first and last values are often not "complete". these options allow to drop them easily.
