### PR TITLE
Ruby 1.8 compatibility

### DIFF
--- a/lib/check_graphite.rb
+++ b/lib/check_graphite.rb
@@ -36,10 +36,10 @@ module CheckGraphite
 
       res.code == "200" || raise("HTTP error code #{res.code}")
 
-      datapoints = JSON(res.body).first["datapoints"]                      
-      res = datapoints.drop(options.dropfirst)
-                      .take(datapoints.length - options.dropfirst - options.droplast)
-                      .reduce({:sum => 0.0, :count => 0}) {|acc, e|
+      datapoints = JSON(res.body).first["datapoints"]
+      res = datapoints.drop(options.dropfirst).
+                      take(datapoints.length - options.dropfirst - options.droplast).
+                      reduce({:sum => 0.0, :count => 0}) {|acc, e|
         if e[0]
           {:sum => acc[:sum] + e[0], :count => acc[:count] + 1}
         else


### PR DESCRIPTION
Hello. There's a tiny bit of syntax in the gem that isn't compatible with Ruby 1.8 (positioning of line-breaks in method chains).

Would you accept this patch so that I don't have to fork the gem?

Thanks for publishing this gem -- it's very helpful.

-Ben
