### PR TITLE
Catch unknown metrics

### DIFF
--- a/lib/check_graphite.rb
+++ b/lib/check_graphite.rb
@@ -35,6 +35,7 @@ module CheckGraphite
       }
 
       raise "HTTP error code #{res.code}" unless res.code == "200"
+      raise "no data returned for target" if res.body == "[]"
 
       datapoints = JSON(res.body).first["datapoints"]
       datapoints = datapoints.slice(


### PR DESCRIPTION
Return a friendly error when Graphite returns an empty response for an unknown metric.

Refactoring and extended test coverage are included in separate commits.
