### PR TITLE
Include reference to the threshold format

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ check_graphite accepts the following options:
 ## How it works
 
 check_graphite, asks for a small window of metrics, and computes an average over the last valid
-points collected, it then checks the value against supplied thresholds.
+points collected, it then checks the value against supplied thresholds. Thresholds are expressed
+in the format given in [The Nagios Developer Guidelines](http://nagiosplug.sourceforge.net/developer-guidelines.html#THRESHOLDFORMAT).
 
 NaN values are not taken into account in the average


### PR DESCRIPTION
I think it would be useful to include a reference to how the thresholds are formatted to save time when trying to understand what you can do with them.
