### PR TITLE
Fix the ignore flag when supplying thresholds

### DIFF
--- a/lib/check_graphite.rb
+++ b/lib/check_graphite.rb
@@ -40,7 +40,7 @@ module CheckGraphite
       raise "HTTP error code #{res.code}" unless res.code == "200"
       if res.body == "[]"
         if options.send("ignore-missing")
-          store_value options.name, -1
+          store_value options.name, 0
           store_message "#{options.name} missing - ignoring"
           return
         else

--- a/spec/check_graphite_spec.rb
+++ b/spec/check_graphite_spec.rb
@@ -88,7 +88,7 @@ describe CheckGraphite::Command do
     end
 
     it "should be ok when ignoring missing data" do
-      stub_const("ARGV", %w{ -H http://your.graphite.host/render -M value.does.not.exist --ignore-missing })
+      stub_const("ARGV", %w{ -H http://your.graphite.host/render -M value.does.not.exist --ignore-missing -w 1 -c 3 })
       c = CheckGraphite::Command.new
       STDOUT.should_receive(:puts).with(/OK: value missing - ignoring/)
       lambda { c.run }.should raise_error SystemExit


### PR DESCRIPTION
Setting the value to `-1` causes the Nagios check to return `CRITICAL`
so let's just set it to zero.